### PR TITLE
Fixes for RandomWeather

### DIFF
--- a/RandomWeatherPlugin/RandomWeather.cs
+++ b/RandomWeatherPlugin/RandomWeather.cs
@@ -42,7 +42,7 @@ public class RandomWeather : CriticalBackgroundService, IAssettoServerAutostart
         float prefixSum = 0.0f;
         foreach (var (weather, weight) in _configuration.WeatherWeights)
         {
-            if (weight != 0 && weight != 0.0)
+            if (weight != 0 || weight != 0.0)
             {
                 prefixSum += weight / weightSum;
                 _weathers.Add(new WeatherWeight

--- a/RandomWeatherPlugin/RandomWeather.cs
+++ b/RandomWeatherPlugin/RandomWeather.cs
@@ -42,12 +42,15 @@ public class RandomWeather : CriticalBackgroundService, IAssettoServerAutostart
         float prefixSum = 0.0f;
         foreach (var (weather, weight) in _configuration.WeatherWeights)
         {
-            prefixSum += weight / weightSum;
-            _weathers.Add(new WeatherWeight
+            if (weight != 0 && weight != 0.0)
             {
-                Weather = weather,
-                PrefixSum = prefixSum,
-            });
+                prefixSum += weight / weightSum;
+                _weathers.Add(new WeatherWeight
+                {
+                    Weather = weather,
+                    PrefixSum = prefixSum,
+                });
+            }
         }
 
         _weathers.Sort((a, b) =>
@@ -104,7 +107,7 @@ public class RandomWeather : CriticalBackgroundService, IAssettoServerAutostart
                     nextWeatherType.WeatherFxType,
                     Math.Round(transitionDuration / 1000.0f),
                     Math.Round(weatherDuration / 60_000.0f, 1));
-                
+
                 _weatherManager.SetWeather(new WeatherData(last.Type, nextWeatherType)
                 {
                     TransitionDuration = transitionDuration,


### PR DESCRIPTION
Fixes the issue that can happen where the last weather can get chosen in the list even if it's set to 0 or 0.0

![values](https://user-images.githubusercontent.com/42766247/201040134-8050bb81-5058-4320-94da-3133965ba92e.png)

Can still result to this

![image](https://user-images.githubusercontent.com/42766247/201040147-dc103782-4782-4311-9636-e8224bd0910b.png)

Because all weather values were getting summed up and added to the 0 values

The Fix removes all 0 and 0.0 weather from the list, so only the weather with values over 0|0.0 from the extra_cfg -> WeatherWeights get used.