### PR TITLE
Implement WrongWayTraffic config param

### DIFF
--- a/AssettoServer/Server/Ai/AiBehavior.cs
+++ b/AssettoServer/Server/Ai/AiBehavior.cs
@@ -182,9 +182,13 @@ public class AiBehavior : CriticalBackgroundService, IAssettoServerAutostart
 
         foreach (var entryCar in _entryCarManager.EntryCars)
         {
+            var (currentSplinePointId, _) = _spline.WorldToSpline(entryCar.Status.Position);
+            var drivingTheRightWay = Vector3.Dot(_spline.Operations.GetForwardVector(currentSplinePointId), entryCar.Status.Velocity) > 0;
+
             if (!entryCar.AiControlled
                 && entryCar.Client?.HasSentFirstUpdate == true
-                && _sessionManager.ServerTimeMilliseconds - entryCar.LastActiveTime < _configuration.Extra.AiParams.PlayerAfkTimeoutMilliseconds)
+                && _sessionManager.ServerTimeMilliseconds - entryCar.LastActiveTime < _configuration.Extra.AiParams.PlayerAfkTimeoutMilliseconds
+                && (_configuration.Extra.AiParams.TwoWayTraffic || _configuration.Extra.AiParams.WrongWayTraffic || drivingTheRightWay))
             {
                 _playerCars.Add(entryCar);
             }
@@ -193,6 +197,7 @@ public class AiBehavior : CriticalBackgroundService, IAssettoServerAutostart
                 entryCar.RemoveUnsafeStates();
                 entryCar.GetInitializedStates(_initializedAiStates, _uninitializedAiStates);
             }
+            
         }
 
         _aiStateCountMetric.Set(_initializedAiStates.Count);

--- a/AssettoServer/Server/Configuration/ACExtraConfiguration.cs
+++ b/AssettoServer/Server/Configuration/ACExtraConfiguration.cs
@@ -272,6 +272,8 @@ public partial class AiParams : ObservableObject
     public float LaneWidthMeters { get; init; } = 3.0f;
     [YamlMember(Description = "Enable two way traffic. This will allow AI cars to spawn in lanes with the opposite direction of travel to the player.")]
     public bool TwoWayTraffic { get; set; } = false;
+    [YamlMember(Description = "Enable traffic spawning if the player is driving the wrong way. Only takes effect when TwoWayTraffic is set to false.")]
+    public bool WrongWayTraffic { get; set; } = true;
     
     [ObservableProperty]
     [property: YamlMember(Description = "AI cornering speed factor. Lower = AI cars will drive slower around corners.")]


### PR DESCRIPTION
I was running into a problem where when spinning out, traffic would spawn behind me. This change allows the owner to choose whether traffic should spawn for cars that are driving the wrong way.