### PR TITLE
Added condition of max Y distance in obstacle detection

### DIFF
--- a/AssettoServer/Server/Ai/AiState.cs
+++ b/AssettoServer/Server/Ai/AiState.cs
@@ -418,7 +418,9 @@ public class AiState
                 {
                     float distance = Vector3.DistanceSquared(playerCar.Status.Position, Status.Position);
 
-                    if (distance < minDistance && GetAngleToCar(playerCar.Status) is > 166 and < 194)
+                    if (distance < minDistance
+                        && GetAngleToCar(playerCar.Status) is > 166 and < 194
+                        && playerCar.Status.Position.Y - Status.Position.Y < 1.5)
                     {
                         minDistance = distance;
                         closestCar = playerCar;


### PR DESCRIPTION
[Trello Item](https://trello.com/c/KneGGGLx/109-fix-heiwajima-obstacle-detection-bug-ignore-y-distance-in-obstacle-detection)

The Y distance comparison may need to be fine tuned / lowered.