### PR TITLE
Added support for trailing ini comments

### DIFF
--- a/AssettoServer/Utils/IniDataExtensions.cs
+++ b/AssettoServer/Utils/IniDataExtensions.cs
@@ -31,6 +31,8 @@ public static class IniDataExtensions
 
             if (!string.IsNullOrEmpty(iniFieldValue))
             {
+                iniFieldValue = iniFieldValue.Split(" ;")[0].TrimEnd();
+                
                 Log.Verbose("{Section}.{Key}={Value}", iniFieldAttribute.Section ?? section, iniFieldAttribute.Key, iniFieldValue);
                 
                 try


### PR DESCRIPTION
Added support for trailing comments

- only for fields
  - `UDP_PORT=9773  ;justatest` will work
- doesn't work with sections
  -  `[SERVER] ; sadfsdf` will throw a parsing exception


Somewhat relevant to #8