### PR TITLE
FastTravelPlugin: Remove UseGroupInheritance, add HideUntypedPoints

### DIFF
--- a/FastTravelPlugin/FastTravelConfiguration.cs
+++ b/FastTravelPlugin/FastTravelConfiguration.cs
@@ -22,6 +22,9 @@ public class FastTravelConfiguration : IValidateConfiguration<FastTravelConfigur
     [YamlMember(Description = "Last zoom level has a fixed position, the track should be aligned to the center of the screen.\nIf map image is shown, prioritize aligning the track with the map image.\nDon't change the values if using Shutoko Revival Project")]
     public List<int> MapFixedTargetPosition = [-2100, 0, 3200];
 
+    [YamlMember(Description = "If true, points without a _TYPE assigned are ignored and not displayed. If false, they will default to SP.")]
+    public bool HideUntypedPoints { get; set; } = false;
+
     [YamlMember(Description = "How teleport icons should cluster when zoomed out.\nTrue (Group mode): Displays only the first point of each type within a group.\nFalse (Distance mode): Displays one point of each type based on proximity, ignoring group names.")]
     public bool UseGroupDrawMode { get; set; } = true;
 

--- a/FastTravelPlugin/FastTravelConfiguration.cs
+++ b/FastTravelPlugin/FastTravelConfiguration.cs
@@ -22,9 +22,6 @@ public class FastTravelConfiguration : IValidateConfiguration<FastTravelConfigur
     [YamlMember(Description = "Last zoom level has a fixed position, the track should be aligned to the center of the screen.\nIf map image is shown, prioritize aligning the track with the map image.\nDon't change the values if using Shutoko Revival Project")]
     public List<int> MapFixedTargetPosition = [-2100, 0, 3200];
 
-    [YamlMember(Description = "If set to true, points without a type inherit the type of the last explicitly typed point within their group.")]
-    public bool UseGroupInheritance { get; set; } = true;
-
     [YamlMember(Description = "How teleport icons should cluster when zoomed out.\nTrue (Group mode): Displays only the first point of each type within a group.\nFalse (Distance mode): Displays one point of each type based on proximity, ignoring group names.")]
     public bool UseGroupDrawMode { get; set; } = true;
 

--- a/FastTravelPlugin/FastTravelModule.cs
+++ b/FastTravelPlugin/FastTravelModule.cs
@@ -18,7 +18,6 @@ public class FastTravelModule : AssettoServerModule<FastTravelConfiguration>
         MapMoveSpeeds = [1, 2, 3, 0],
         ShowMapImage = false,
         MapFixedTargetPosition = [0, 0, 0],
-        UseGroupInheritance = true,
         UseGroupDrawMode = true,
         DistanceModeRange = 100
     };

--- a/FastTravelPlugin/FastTravelModule.cs
+++ b/FastTravelPlugin/FastTravelModule.cs
@@ -18,6 +18,7 @@ public class FastTravelModule : AssettoServerModule<FastTravelConfiguration>
         MapMoveSpeeds = [1, 2, 3, 0],
         ShowMapImage = false,
         MapFixedTargetPosition = [0, 0, 0],
+        HideUntypedPoints = false,
         UseGroupDrawMode = true,
         DistanceModeRange = 100
     };

--- a/FastTravelPlugin/FastTravelPlugin.cs
+++ b/FastTravelPlugin/FastTravelPlugin.cs
@@ -49,7 +49,6 @@ public class FastTravelPlugin : IHostedService
             ["mapMoveSpeeds"] = $"\"{JsonSerializer.Serialize(configuration.MapMoveSpeeds)}\"",
             ["showMapImg"] = configuration.ShowMapImage ? "true" : "false",
             ["disableCollisions"] = configuration.DisableCollisions ? "true" : "false",
-            ["useGroupInheritance"] = configuration.UseGroupInheritance ? "true" : "false",
             ["useGroupDrawMode"] = configuration.UseGroupDrawMode ? "true" : "false",
             ["distanceModeRange"] = configuration.DistanceModeRange
         });

--- a/FastTravelPlugin/FastTravelPlugin.cs
+++ b/FastTravelPlugin/FastTravelPlugin.cs
@@ -49,6 +49,7 @@ public class FastTravelPlugin : IHostedService
             ["mapMoveSpeeds"] = $"\"{JsonSerializer.Serialize(configuration.MapMoveSpeeds)}\"",
             ["showMapImg"] = configuration.ShowMapImage ? "true" : "false",
             ["disableCollisions"] = configuration.DisableCollisions ? "true" : "false",
+            ["hideUntypedPoints"] = configuration.HideUntypedPoints ? "true" : "false",
             ["useGroupDrawMode"] = configuration.UseGroupDrawMode ? "true" : "false",
             ["distanceModeRange"] = configuration.DistanceModeRange
         });

--- a/FastTravelPlugin/lua/fasttravel.lua
+++ b/FastTravelPlugin/lua/fasttravel.lua
@@ -11,7 +11,6 @@ local config = ac.configValues({
     mapZoomValues = "",          -- { 100, 1000, 4000, 15000 },
     mapMoveSpeeds = "",          -- { 1, 5, 20, 0 },
     showMapImg = true,
-    useGroupInheritance = true,
     useGroupDrawMode = true,
     distanceModeRange = 100
 })
@@ -31,17 +30,15 @@ local trackCompassOffset = 24 -- for SRP
 local font = 'Segoe UI'
 local fontBold = 'Segoe UI;Weight=Bold'
 
---c1xtz: read teleports from server options, requires 'POINT_<num>_TYPE = PA/ST' to be added to the teleports in csp_extra_options.ini to not show up as the default.
---c1xtz: additional custom types can be created as long as a corresponding 'mapicon_<type>.png' is in the images folder. example: 'POINT_1_TYPE = GS' & 'mapicon_gs.png' for a gas station type.
---c1xtz: points inside of group inherite the type of the point before, meaning if 'POINT_1_TYPE = PA' and POINT_2 is not specifically given a type, it will inherit the PA type from point 1.
---c1xtz: this makes it possible to have multiple types per group, although only the first point per unique type is shown (see tpdrawing:)
+--c1xtz: read teleports from server options, requires 'POINT_X_TYPE = PA/ST' to be added to the teleports in csp_extra_options.ini, otherwise they show up as the default.
+--c1xtz: additional custom types can be created as long as a corresponding 'mapicon_<type>.png' is in the wwwwroot folder. example: 'POINT_1_TYPE = GS' + 'mapicon_gs.png' for a gas station type.
 local extraOptions = ac.INIConfig.onlineExtras()
-local onlineTeleports, encounteredTypes = {}, {}
+local onlineTeleports = {}
 local defaultType = 'sp'
 
 local function getTeleports()
     if not extraOptions then return end
-    onlineTeleports, encounteredTypes = {}, {}
+    onlineTeleports = {}
     for _, points in extraOptions:iterateValues('TELEPORT_DESTINATIONS', 'POINT') do
         if points:match('_POS$') then
             local pointName = extraOptions:get('TELEPORT_DESTINATIONS', points:gsub('_POS$', ''), '')
@@ -49,11 +46,7 @@ local function getTeleports()
             local position = extraOptions:get('TELEPORT_DESTINATIONS', points, vec3())
             local heading = tonumber(extraOptions:get('TELEPORT_DESTINATIONS', points:gsub('_POS$', '_HEADING'), 0))
             local typeName = extraOptions:get('TELEPORT_DESTINATIONS', points:gsub('_POS$', '_TYPE'), ''):lower()
-            if typeName == '' then
-                typeName = (config.useGroupInheritance and encounteredTypes[groupName]) or defaultType
-            else
-                if config.useGroupInheritance then encounteredTypes[groupName] = typeName end
-            end
+            if typeName == '' then typeName = defaultType end
             table.insert(onlineTeleports, { typeName, groupName, position, heading, pointName })
         end
     end
@@ -119,7 +112,7 @@ local debugPos = mapFixedTargetPosition:clone()
 local debugOrigPos = mapFixedTargetPosition:clone()
 local debugZoom, debugOrigZoom = table.clone(mapZoomValue), table.clone(mapZoomValue)
 local debugSpeed, debugOrigSpeed = table.clone(mapMoveSpeed), table.clone(mapMoveSpeed)
-local debugUseGroupInheritance, debugOrigUseGroupInheritance = config.useGroupInheritance, config.useGroupInheritance
+
 local debugUseGroupDrawMode, debugOrigUseGroupDrawMode = config.useGroupDrawMode, config.useGroupDrawMode
 local debugDistanceModeRange, debugOrigDistanceModeRange = config.distanceModeRange, config.distanceModeRange
 local debugOnlineExtra = nil
@@ -324,32 +317,26 @@ local function window_FastTravelDebug()
         end)
 
         ui.tabItem("Point Display Settings", function()
-            if ui.checkbox("Use Group Inheritance", debugUseGroupInheritance) then
-                debugUseGroupInheritance = not debugUseGroupInheritance
-                config.useGroupInheritance = debugUseGroupInheritance
-                getTeleports()
-            end
 
             if ui.checkbox("Use Group Draw Mode", debugUseGroupDrawMode) then
                 debugUseGroupDrawMode = not debugUseGroupDrawMode
                 config.useGroupDrawMode = debugUseGroupDrawMode
             end
 
-            local rangeValue, rangeChanged = ui.slider("##distanceRange", debugDistanceModeRange, 1, 1000, "Distance Mode Range: %.0f")
-            if rangeChanged then
-                debugDistanceModeRange = rangeValue
-                config.distanceModeRange = debugDistanceModeRange
+            if not debugUseGroupDrawMode then 
+                local rangeValue, rangeChanged = ui.slider("##distanceRange", debugDistanceModeRange, 1, 1000, "Distance Mode Range: %.0f")
+                if rangeChanged then
+                    debugDistanceModeRange = rangeValue
+                    config.distanceModeRange = debugDistanceModeRange
+                end
             end
 
             ui.separator()
             if ui.button("Reset") then
-                debugUseGroupInheritance = debugOrigUseGroupInheritance
-                config.useGroupInheritance = debugOrigUseGroupInheritance
                 debugUseGroupDrawMode = debugOrigUseGroupDrawMode
                 config.useGroupDrawMode = debugOrigUseGroupDrawMode
                 debugDistanceModeRange = debugOrigDistanceModeRange
                 config.distanceModeRange = debugOrigDistanceModeRange
-                getTeleports()
             end
         end)
 
@@ -369,7 +356,6 @@ local function window_FastTravelDebug()
             exportConfig[#exportConfig + 1] = "- " .. math.round(mapFixedTargetPosition.y)
             exportConfig[#exportConfig + 1] = "- " .. math.round(mapFixedTargetPosition.z)
             exportConfig[#exportConfig + 1] = "RequireCollisionDisable: " .. tostring(config.disableCollisions)
-            exportConfig[#exportConfig + 1] = "UseGroupInheritance: " .. tostring(config.useGroupInheritance)
             exportConfig[#exportConfig + 1] = "UseGroupDrawMode: " .. tostring(config.useGroupDrawMode)
             exportConfig[#exportConfig + 1] = "DistanceModeRange: " .. math.round(config.distanceModeRange)
             ac.setClipboardText(table.concat(exportConfig, "\n"))
@@ -440,7 +426,6 @@ function script.drawUI(dt)
                 map_opacity = 0
             end
 
-            --c1xtz: tpdrawing: if config.useGroupDrawMode is true, only draws the first point of each unique type per group, otherwise only draw the first icon of each type based on config.distanceModeRange distance.
             hoverMark = -1
             local selected = {}
             local displayedPoints = {}
@@ -453,6 +438,7 @@ function script.drawUI(dt)
                     local picked = false
 
                     if mapZoom > 2 then
+                        --c1xtz: if config.useGroupDrawMode is true, only draws the first point of each unique type per group, otherwise only draw the first icon of each type based on config.distanceModeRange distance.
                         if config.useGroupDrawMode then
                             local group = teleport[2]
                             displayedPoints[group] = displayedPoints[group] or {}
@@ -488,13 +474,13 @@ function script.drawUI(dt)
                 end
             end
 
-            --c1xtz: draw order stuff, making sure POINT_1 would be drawn ABOVE POINT_2
+            --c1xtz: draw order fixing, making sure POINT_1 would be drawn ABOVE POINT_2
             for i = #selected, 1, -1 do
                 local point = selected[i]
                 ui.drawImage(baseUrl .. 'mapicon_' .. point.teleport[1] .. '.png', point.screenPos - vec2(40, 40), point.screenPos + vec2(40, 40))
             end
 
-            --c1xtz: draw order stuff 2, making sure that when hovering over a teleport icon while zooming in the mouse keeps sticking to the hovered point
+            --c1xtz: more draw order fixing, making sure that when hovering over a teleport icon while zooming in the mouse keeps sticking to the hovered point
             for i = 1, #selected do
                 local point = selected[i]
                 if mp > point.screenPos - vec2(30, 30) and mp < point.screenPos + vec2(30, 30) then

--- a/FastTravelPlugin/lua/fasttravel.lua
+++ b/FastTravelPlugin/lua/fasttravel.lua
@@ -118,6 +118,7 @@ local debugSpeed, debugOrigSpeed = table.clone(mapMoveSpeed), table.clone(mapMov
 
 local debugUseGroupDrawMode, debugOrigUseGroupDrawMode = config.useGroupDrawMode, config.useGroupDrawMode
 local debugDistanceModeRange, debugOrigDistanceModeRange = config.distanceModeRange, config.distanceModeRange
+local debugHideUntypedPoints, debugOrigHideUntypedPoints = config.hideUntypedPoints, config.hideUntypedPoints
 local debugOnlineExtra = nil
 local debugWindowOpen = false
 
@@ -321,6 +322,12 @@ local function window_FastTravelDebug()
 
         ui.tabItem("Point Display Settings", function()
 
+            if ui.checkbox("Hide Untyped Points", debugHideUntypedPoints) then
+                debugHideUntypedPoints = not debugHideUntypedPoints
+                config.hideUntypedPoints = debugHideUntypedPoints
+                getTeleports()
+            end
+
             if ui.checkbox("Use Group Draw Mode", debugUseGroupDrawMode) then
                 debugUseGroupDrawMode = not debugUseGroupDrawMode
                 config.useGroupDrawMode = debugUseGroupDrawMode
@@ -336,10 +343,9 @@ local function window_FastTravelDebug()
 
             ui.separator()
             if ui.button("Reset") then
-                debugUseGroupDrawMode = debugOrigUseGroupDrawMode
-                config.useGroupDrawMode = debugOrigUseGroupDrawMode
-                debugDistanceModeRange = debugOrigDistanceModeRange
-                config.distanceModeRange = debugOrigDistanceModeRange
+                debugHideUntypedPoints, config.hideUntypedPoints = debugOrigHideUntypedPoints, debugOrigHideUntypedPoints
+                debugUseGroupDrawMode, config.useGroupDrawMode = debugOrigUseGroupDrawMode, debugOrigUseGroupDrawMode
+                debugDistanceModeRange, config.distanceModeRange = debugOrigDistanceModeRange, debugOrigDistanceModeRange
             end
         end)
 

--- a/FastTravelPlugin/lua/fasttravel.lua
+++ b/FastTravelPlugin/lua/fasttravel.lua
@@ -11,6 +11,7 @@ local config = ac.configValues({
     mapZoomValues = "",          -- { 100, 1000, 4000, 15000 },
     mapMoveSpeeds = "",          -- { 1, 5, 20, 0 },
     showMapImg = true,
+    hideUntypedPoints = false,
     useGroupDrawMode = true,
     distanceModeRange = 100
 })
@@ -46,8 +47,10 @@ local function getTeleports()
             local position = extraOptions:get('TELEPORT_DESTINATIONS', points, vec3())
             local heading = tonumber(extraOptions:get('TELEPORT_DESTINATIONS', points:gsub('_POS$', '_HEADING'), 0))
             local typeName = extraOptions:get('TELEPORT_DESTINATIONS', points:gsub('_POS$', '_TYPE'), ''):lower()
-            if typeName == '' then typeName = defaultType end
-            table.insert(onlineTeleports, { typeName, groupName, position, heading, pointName })
+            if typeName == '' and not config.hideUntypedPoints then typeName = defaultType end
+            if typeName ~= '' then
+                table.insert(onlineTeleports, { typeName, groupName, position, heading, pointName })
+            end
         end
     end
 end


### PR DESCRIPTION
Someone convinced me that unassigned points being defaulted to SP while UseGroupInheritance would be overwritting some of those same unassigned points could cause confusion, especially if using a lot of teleport destinations. Also added HideUntypedPoints so that the defaulting to SP can be toggled off too, meaning untyped teleport locations will not show up on the mapview at all.