### PR TITLE
Removed internal from HasUpdateToSend

### DIFF
--- a/AssettoServer/Server/EntryCar.cs
+++ b/AssettoServer/Server/EntryCar.cs
@@ -26,7 +26,7 @@ public partial class EntryCar : IEntryCar<ACTcpClient>
     public bool ForceLights { get; internal set; }
 
     public long LastActiveTime { get; internal set; }
-    public bool HasUpdateToSend { get; internal set; }
+    public bool HasUpdateToSend { get; set; }
     public int TimeOffset { get; internal set; }
     public byte SessionId { get; }
     public uint LastRemoteTimestamp { get; internal set; }


### PR DESCRIPTION
I made a plugin to playback AC's replays file as bots, mainly used for tandem drifting, it's kinda hacky but it works, removing "internal" from the HasUpdateToSend property would let me not have to resdistribute AssettoServer to make the plugin work.