### PR TITLE
FastTravelPlugin: Added missing MinimumCSPVersion check

### DIFF
--- a/FastTravelPlugin/FastTravelPlugin.cs
+++ b/FastTravelPlugin/FastTravelPlugin.cs
@@ -23,14 +23,13 @@ public class FastTravelPlugin : IHostedService
     {
         _aiSpline = aiSpline ?? throw new ConfigurationException("FastTravelPlugin does not work with AI traffic disabled");
 
-        if (configuration.DisableCollisions && serverConfiguration.CSPTrackOptions.MinimumCSPVersion < CSPVersion.V0_2_8)
-        {
-            throw new ConfigurationException("FastTravelPlugin needs a minimum required CSP version of 0.2.8 (3424)");
-        }
+        var requiredVersion = configuration.DisableCollisions ? CSPVersion.V0_2_8 : CSPVersion.V0_2_0;
+        var requiredVersionString = configuration.DisableCollisions ? "0.2.8 (3424)" : "0.2.0 (2651)";
+        var minimumVersion = serverConfiguration.CSPTrackOptions.MinimumCSPVersion ?? throw new ConfigurationException($"FastTravelPlugin needs a minimum required CSP version of {requiredVersionString}");
 
-        if (!configuration.DisableCollisions && serverConfiguration.CSPTrackOptions.MinimumCSPVersion < CSPVersion.V0_2_0)
+        if (minimumVersion < requiredVersion)
         {
-            throw new ConfigurationException("FastTravelPlugin needs a minimum required CSP version of 0.2.0 (2651)");
+            throw new ConfigurationException($"FastTravelPlugin needs a minimum required CSP version of {requiredVersionString}");
         }
 
         if (!serverConfiguration.Extra.EnableClientMessages)

--- a/FastTravelPlugin/lua/fasttravel.lua
+++ b/FastTravelPlugin/lua/fasttravel.lua
@@ -331,6 +331,7 @@ local function window_FastTravelDebug()
             if ui.checkbox("Use Group Draw Mode", debugUseGroupDrawMode) then
                 debugUseGroupDrawMode = not debugUseGroupDrawMode
                 config.useGroupDrawMode = debugUseGroupDrawMode
+                getTeleports()
             end
 
             if not debugUseGroupDrawMode then 
@@ -346,6 +347,7 @@ local function window_FastTravelDebug()
                 debugHideUntypedPoints, config.hideUntypedPoints = debugOrigHideUntypedPoints, debugOrigHideUntypedPoints
                 debugUseGroupDrawMode, config.useGroupDrawMode = debugOrigUseGroupDrawMode, debugOrigUseGroupDrawMode
                 debugDistanceModeRange, config.distanceModeRange = debugOrigDistanceModeRange, debugOrigDistanceModeRange
+                getTeleports()
             end
         end)
 

--- a/FastTravelPlugin/lua/fasttravel.lua
+++ b/FastTravelPlugin/lua/fasttravel.lua
@@ -26,7 +26,7 @@ local baseUrl = 'http://' .. ac.getServerIP() .. ':' .. ac.getServerPortHTTP() .
 local supportAPI_physics = physics.setGentleStop ~= nil
 local supportAPI_collision = physics.disableCarCollisions ~= nil
 local supportAPI_matrix = ac.getPatchVersionCode() >= 3037
-local trackCompassOffset = 24 -- for SRP
+local trackCompassOffset = ac.getCompassAngle(vec3(0, 0, -1))
 
 local font = 'Segoe UI'
 local fontBold = 'Segoe UI;Weight=Bold'


### PR DESCRIPTION
60f541c: calculates `trackCompassOffset` from forward vector instead of hardcoding it, fixes incorrectly rotated player arrow images on tracks that aren't srp