### PR TITLE
RandomWeatherPlugin: RandomizeInitialWeather option + more robust config validation

### DIFF
--- a/RandomWeatherPlugin/RandomWeather.cs
+++ b/RandomWeatherPlugin/RandomWeather.cs
@@ -119,13 +119,15 @@ public class RandomWeather : BackgroundService
     {
         int weatherDuration = 1000;
         int transitionDuration = 1000;
+        bool firstRun = true;
 
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
                 weatherDuration = Random.Shared.Next(_configuration.MinWeatherDurationMilliseconds, _configuration.MaxWeatherDurationMilliseconds);
-                transitionDuration = Random.Shared.Next(_configuration.MinTransitionDurationMilliseconds, _configuration.MaxTransitionDurationMilliseconds);
+                transitionDuration = (firstRun && _configuration.RandomizeInitialWeather) ? 0 : Random.Shared.Next(_configuration.MinTransitionDurationMilliseconds, _configuration.MaxTransitionDurationMilliseconds);
+                firstRun = false;
 
                 var next = PickRandom();
                 var nextWeatherType = _weatherTypeProvider.GetWeatherType(next);

--- a/RandomWeatherPlugin/RandomWeather.cs
+++ b/RandomWeatherPlugin/RandomWeather.cs
@@ -47,7 +47,7 @@ public class RandomWeather : BackgroundService
                 RainWater = last.RainWater,
                 TrackGrip = last.TrackGrip
             });
-        
+
             RecalculateWeights(_configuration.WeatherTransitions[next.WeatherFxType]);
         }
         else if (_configuration.Mode == RandomWeatherMode.Default)
@@ -62,7 +62,10 @@ public class RandomWeather : BackgroundService
     }
 
     private void RecalculateWeights(Dictionary<WeatherFxType,float> input)
+    private void RecalculateWeights(Dictionary<WeatherFxType, float> input)
     {
+        _weathers.Clear();
+
         float weightSum = input
             .Select(w => w.Value)
             .Sum();
@@ -138,7 +141,7 @@ public class RandomWeather : BackgroundService
                     nextWeatherType.WeatherFxType,
                     Math.Round(transitionDuration / 1000.0f),
                     Math.Round(weatherDuration / 60_000.0f, 1));
-                
+
                 _weatherManager.SetWeather(new WeatherData(last.Type, nextWeatherType)
                 {
                     TransitionDuration = transitionDuration,
@@ -154,7 +157,7 @@ public class RandomWeather : BackgroundService
                     RainWater = last.RainWater,
                     TrackGrip = last.TrackGrip
                 });
-                
+
                 if (_configuration.Mode == RandomWeatherMode.TransitionTable)
                     RecalculateWeights(_configuration.WeatherTransitions[next]);
             }

--- a/RandomWeatherPlugin/RandomWeather.cs
+++ b/RandomWeatherPlugin/RandomWeather.cs
@@ -27,9 +27,6 @@ public class RandomWeather : BackgroundService
 
         if (_configuration.Mode == RandomWeatherMode.TransitionTable)
         {
-            if (_configuration.WeatherTransitions.Count == 0)
-                throw new ConfigurationException("No entries were found in the WeatherTransitions list");
-            
             var next = _weatherTypeProvider.GetWeatherType(_configuration.WeatherTransitions.First().Key);
             var last = _weatherManager.CurrentWeather;
             _weatherManager.SetWeather(new WeatherData(last.Type, next)
@@ -52,16 +49,10 @@ public class RandomWeather : BackgroundService
         }
         else if (_configuration.Mode == RandomWeatherMode.Default)
         {
-            if (_configuration.WeatherWeights.Count == 0)
-                throw new ConfigurationException("No entries were found in the WeatherWeights list");
-
-            _configuration.WeatherWeights[WeatherFxType.None] = 0;
-
             RecalculateWeights(_configuration.WeatherWeights);
         }
     }
 
-    private void RecalculateWeights(Dictionary<WeatherFxType,float> input)
     private void RecalculateWeights(Dictionary<WeatherFxType, float> input)
     {
         _weathers.Clear();
@@ -73,7 +64,7 @@ public class RandomWeather : BackgroundService
         float prefixSum = 0.0f;
         foreach (var (weather, weight) in input)
         {
-            if (weight > 0)
+            if (weight > 0 && weather != WeatherFxType.None)
             {
                 prefixSum += weight / weightSum;
                 _weathers.Add(new WeatherWeight

--- a/RandomWeatherPlugin/RandomWeatherConfiguration.cs
+++ b/RandomWeatherPlugin/RandomWeatherConfiguration.cs
@@ -21,6 +21,9 @@ public class RandomWeatherConfiguration : IValidateConfiguration<RandomWeatherCo
     [YamlMember(Description = "Maximum weather transition duration")]
     public int MaxTransitionDurationSeconds { get; set; } = 600;
     
+    [YamlMember(Description = "If true, the server will start and apply the first random weather instantly, skipping the initial transition from the weather configured in server_cfg.ini")]
+    public bool RandomizeInitialWeather { get; set; } = false;
+    
     [YamlMember(Description = "Weights for weather transition, only listed weathers will be counted\nCheck the reference config to see the structure")]
     public Dictionary<WeatherFxType, Dictionary<WeatherFxType, float>> WeatherTransitions { get; init; } = new();
     [YamlMember(Description = "Weights for random weather selection, removing a weight or setting it to 0 blacklists a weather\nYou can also use decimals like 0.1")]

--- a/RandomWeatherPlugin/RandomWeatherConfigurationValidator.cs
+++ b/RandomWeatherPlugin/RandomWeatherConfigurationValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using AssettoServer.Shared.Weather;
 
 namespace RandomWeatherPlugin;
 
@@ -6,11 +7,42 @@ public class RandomWeatherConfigurationValidator : AbstractValidator<RandomWeath
 {
     public RandomWeatherConfigurationValidator()
     {
-        RuleForEach(cfg => cfg.WeatherWeights).ChildRules(ww =>
-        {
-            ww.RuleFor(w => w.Value).GreaterThanOrEqualTo(0);
-        });
         RuleFor(cfg => cfg.MinWeatherDurationMinutes).LessThanOrEqualTo(cfg => cfg.MaxWeatherDurationMinutes);
         RuleFor(cfg => cfg.MinTransitionDurationSeconds).LessThanOrEqualTo(cfg => cfg.MaxTransitionDurationSeconds);
+        When(cfg => cfg.Mode == RandomWeatherMode.TransitionTable, () =>
+        {
+            RuleFor(cfg => cfg.WeatherTransitions)
+                .NotNull()
+                .DependentRules(() =>
+                {
+                    RuleFor(cfg => cfg.WeatherTransitions)
+                        .NotEmpty();
+                    RuleForEach(cfg => cfg.WeatherTransitions)
+                        .Must(x => x.Value.Values.Any(v => v > 0))
+                        .WithMessage("Each WeatherTransitions entry must contain at least one destination weather with a weight greater than 0");
+                    RuleFor(cfg => cfg.WeatherTransitions)
+                        .Must(wt =>
+                        {
+                            var destinations = wt.Values.SelectMany(d => d.Keys).Distinct();
+                            return destinations.All(d => d == WeatherFxType.None || wt.ContainsKey(d));
+                        }).WithMessage("Every weather that can be transitioned to must also have its own WeatherTransitions section");
+                });
+        });
+        When(cfg => cfg.Mode == RandomWeatherMode.Default, () =>
+        {
+            RuleFor(cfg => cfg.WeatherWeights)
+                .NotNull()
+                .DependentRules(() =>
+                {
+                    RuleFor(cfg => cfg.WeatherWeights)
+                        .Must(ww => ww.Values.Any(v => v > 0))
+                        .WithMessage("At least one entry in WeatherWeights must have a weight greater than 0");
+                    RuleForEach(cfg => cfg.WeatherWeights)
+                        .ChildRules(ww => { ww.RuleFor(w => w.Value).GreaterThanOrEqualTo(0); });
+                    RuleFor(cfg => cfg.WeatherWeights)
+                        .Must(ww => !ww.ContainsKey(WeatherFxType.None) || ww[WeatherFxType.None] <= 0)
+                        .WithMessage("WeatherFX Type \"None\" cannot be used as a weather weight");
+                });
+        });
     }
 }

--- a/RandomWeatherPlugin/RandomWeatherConfigurationValidator.cs
+++ b/RandomWeatherPlugin/RandomWeatherConfigurationValidator.cs
@@ -12,14 +12,18 @@ public class RandomWeatherConfigurationValidator : AbstractValidator<RandomWeath
         When(cfg => cfg.Mode == RandomWeatherMode.TransitionTable, () =>
         {
             RuleFor(cfg => cfg.WeatherTransitions)
-                .NotNull()
+                .NotEmpty()
                 .DependentRules(() =>
                 {
                     RuleFor(cfg => cfg.WeatherTransitions)
-                        .NotEmpty();
+                        .Must(wt => !wt.ContainsKey(WeatherFxType.None))
+                        .WithMessage("WeatherFX Type \"None\" cannot be used as a weather");
                     RuleForEach(cfg => cfg.WeatherTransitions)
-                        .Must(x => x.Value.Values.Any(v => v > 0))
-                        .WithMessage("Each WeatherTransitions entry must contain at least one destination weather with a weight greater than 0");
+                        .Must(x => !x.Value.ContainsKey(WeatherFxType.None) || x.Value[WeatherFxType.None] <= 0)
+                        .WithMessage("WeatherFX Type \"None\" cannot be used as a weather");
+                    RuleForEach(cfg => cfg.WeatherTransitions)
+                        .Must(wt => wt.Value.Values.Any(v => v > 0))
+                        .WithMessage("Every WeatherTransitions entry must contain at least one destination weather with a weight greater than 0");
                     RuleFor(cfg => cfg.WeatherTransitions)
                         .Must(wt =>
                         {
@@ -31,17 +35,17 @@ public class RandomWeatherConfigurationValidator : AbstractValidator<RandomWeath
         When(cfg => cfg.Mode == RandomWeatherMode.Default, () =>
         {
             RuleFor(cfg => cfg.WeatherWeights)
-                .NotNull()
+                .NotEmpty()
                 .DependentRules(() =>
                 {
+                    RuleFor(cfg => cfg.WeatherWeights)
+                        .Must(ww => !ww.ContainsKey(WeatherFxType.None) || ww[WeatherFxType.None] <= 0)
+                        .WithMessage("WeatherFX Type \"None\" cannot be used as a weather");
                     RuleFor(cfg => cfg.WeatherWeights)
                         .Must(ww => ww.Values.Any(v => v > 0))
                         .WithMessage("At least one entry in WeatherWeights must have a weight greater than 0");
                     RuleForEach(cfg => cfg.WeatherWeights)
                         .ChildRules(ww => { ww.RuleFor(w => w.Value).GreaterThanOrEqualTo(0); });
-                    RuleFor(cfg => cfg.WeatherWeights)
-                        .Must(ww => !ww.ContainsKey(WeatherFxType.None) || ww[WeatherFxType.None] <= 0)
-                        .WithMessage("WeatherFX Type \"None\" cannot be used as a weather weight");
                 });
         });
     }


### PR DESCRIPTION
Adds the option to skip the very first random weather transition period from the initial weather set in server_cfg.ini

9e9d920 - Fixes `RecalculateWeatherWeights` never clearing `_weathers` before adding to it. In TransitionTable mode it's called every cycle, so the list just kept growing for as long as the server is running.
b4ee6e9 + d4a17cc - Try to make misconfigurations more difficult, and replace some runtime throws with configuration validation